### PR TITLE
Updated temperature to show in Celsius

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ To run the application, execute the following command in the project directory:
 python run.py
 Then, open your web browser and navigate to http://localhost:5000.
 
+The temperature is now displayed in Celsius degrees.
+
 # Files
 
 - app/views.py: Contains the Flask routes and the main logic of the application.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <h2>Weather in {{ weather.city }}</h2>
         <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
         <p>{{ weather.description }}</p>
-        <p>Temperature: {{ weather.temperature }}</p>
+        <p>Temperature: {{ weather.temperature }} °C</p>
     </div>
     {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -13,10 +13,13 @@ def index():
 
         response = requests.get(url).json()
 
+        temperature_kelvin = response['main']['temp']
+        temperature_celsius = temperature_kelvin - 273.15
+
         weather = {
             'country': response['sys']['country'],
             'city': response['name'],
-            'temperature': response['main']['temp'],
+            'temperature': temperature_celsius,
             'description': response['weather'][0]['description'],
             'icon': response['weather'][0]['icon'],
         }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,3 +17,5 @@ class TestViews(unittest.TestCase):
             response = self.app.post('/', data={'city': city})
             self.assertEqual(response.status_code, 200)
             self.assertIn(bytes(city, 'utf-8'), response.data)
+            self.assertIn(b'Temperature: ', response.data)
+            self.assertIn(b' \xc2\xb0C', response.data)


### PR DESCRIPTION
Related to #1

Update the weather app to display temperature in Celsius degrees.

* **Convert temperature in `app/views.py`**
  - Fetch temperature in Kelvin from OpenWeatherMap API.
  - Convert temperature from Kelvin to Celsius.
  - Update `temperature` key in the `weather` dictionary to store temperature in Celsius.

* **Update temperature display in `app/templates/index.html`**
  - Display temperature in Celsius with "°C" suffix.

* **Document temperature conversion in `README.md`**
  - Add note in the `Usage` section about temperature being displayed in Celsius.

* **Add tests for temperature conversion in `tests/test_views.py`**
  - Verify that the temperature is displayed in Celsius in the response data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Manuss20/the-weather-app/issues/1?shareId=ff13edc5-3ad6-4057-9b9b-9bd5e32a5ef4).